### PR TITLE
[Fix] Fixing room message form

### DIFF
--- a/base/templates/base/room.html
+++ b/base/templates/base/room.html
@@ -113,10 +113,15 @@
 
       </div>
       <div class="room__message">
-        <form action="" method="POST">
-          {% csrf_token %}
-          <input name="body" placeholder="Write your message here..." />
-        </form>
+        {% if request.user.is_authenticated %}
+          <form action="" method="POST">
+            {% csrf_token %}
+            <input name="body" placeholder="Write your message here..." />
+          </form>
+        {% else %}
+        <p class="room__login__message"> <a href="{% url 'login' %}">Log in </a> to write your message </p>
+        {% endif %}
+        
       </div>
     </div>
     <!-- Room End -->

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1046,7 +1046,12 @@ a {
   margin-bottom: 4rem;
   height: 64%;
 }
+.room__login__message{
+  background: var(--color-dark-light);
+  padding: 0.5rem 1.5rem;
+  border-radius: 0.7rem;
 
+}
 .threads h3 {
   text-transform: uppercase;
   font-weight: 500;


### PR DESCRIPTION
If user is not logged and tries to add a new message the website would break , because the form was visible. Added a if condition that renders either the form or a paragraph with link to log in.
**Now**
**Not logged user**
<img width="1440" alt="Screenshot 2021-10-14 at 15 23 09" src="https://user-images.githubusercontent.com/78023091/137337514-348dff60-7134-43a2-b312-cfba624da91b.png">
**Logged user**
<img width="1440" alt="Screenshot 2021-10-14 at 15 23 29" src="https://user-images.githubusercontent.com/78023091/137337532-8810bfe7-3faa-45ee-ab92-74fc50b4bac3.png">

**Before**
<img width="1440" alt="Screenshot 2021-10-14 at 15 25 19" src="https://user-images.githubusercontent.com/78023091/137337536-8e85dae2-137d-4678-8ffe-c1106bf10345.png">

**Error when you try to add message**
<img width="1439" alt="Screenshot 2021-10-14 at 15 25 49" src="https://user-images.githubusercontent.com/78023091/137337541-f39e806a-1f2d-4864-9404-8093fd49118c.png">
